### PR TITLE
Feature: Added actor data to `additionalDiceFormula` `Roll` instances to enable accessing actor stats

### DIFF
--- a/documents/character.mjs
+++ b/documents/character.mjs
@@ -37,6 +37,16 @@ export class CharacterData extends foundry.abstract.DataModel {
                 attributeId: new foundry.data.fields.StringField({
                     initial: AttributeIdNoSwing
                 }),
+                d6roll: new foundry.data.fields.NumberField({
+                    integer: true,
+                    min: 0,
+                    initial: 0
+                }),
+                attributeBonus: new foundry.data.fields.NumberField({
+                    integer: true,
+                    min: 0,
+                    initial: 0
+                }),
                 value: new foundry.data.fields.NumberField({
                     integer: true,
                     min: 0,
@@ -303,7 +313,10 @@ export class Character extends Actor {
         if (chosenAttributeDie != null) {
             this.update({
                 "system.swing.attributeId": chosenAttributeDie.attribute._id,
+                "system.swing.d6roll": chosenAttributeDie.roll,
+                "system.swing.attributeBonus": chosenAttributeDie.attribute.system.modifier,
                 "system.swing.value": chosenAttributeDie.roll + chosenAttributeDie.attribute.system.modifier
+            
             });
         }
         

--- a/documents/character.mjs
+++ b/documents/character.mjs
@@ -128,7 +128,7 @@ export class Character extends Actor {
         }
 
         if (additionalDiceFormula?.toHit) {
-            const additionalRollToHit = await new Roll(additionalDiceFormula.toHit).evaluate();
+            const additionalRollToHit = await new Roll(additionalDiceFormula.toHit, this.system).evaluate();
             rolls.push(additionalRollToHit);
             templateValues.additionalDiceToHit = {
                 formula: additionalRollToHit.formula,
@@ -139,7 +139,7 @@ export class Character extends Actor {
         }
 
         if (additionalDiceFormula?.toEffect) {
-            const additionalRollToEffect = await new Roll(additionalDiceFormula.toEffect).evaluate();
+            const additionalRollToEffect = await new Roll(additionalDiceFormula.toEffect, this.system).evaluate();
             rolls.push(additionalRollToEffect);
             templateValues.additionalDiceToEffect = {
                 formula: additionalRollToEffect.formula,
@@ -293,7 +293,7 @@ export class Character extends Actor {
         } : null;
 
         const attributeDice = await this.#rollAttributeDice(existingSwingAttributeDie);
-        const additionalDice = additionalDiceFormula?.toEffect ? await new Roll(additionalDiceFormula.toEffect).evaluate() : null;
+        const additionalDice = additionalDiceFormula?.toEffect ? await new Roll(additionalDiceFormula.toEffect, this.system).evaluate() : null;
         await this.#renderAttributeDice(options.rollTitle, attributeDice, additionalDice);
 
         const availableAttributeDice = attributeDice.filter((attributeDie) => attributeDie.attribute.system.status == AttributeStatus.Normal);

--- a/documents/character.mjs
+++ b/documents/character.mjs
@@ -44,7 +44,6 @@ export class CharacterData extends foundry.abstract.DataModel {
                 }),
                 attributeBonus: new foundry.data.fields.NumberField({
                     integer: true,
-                    min: 0,
                     initial: 0
                 }),
                 value: new foundry.data.fields.NumberField({
@@ -318,7 +317,6 @@ export class Character extends Actor {
                 "system.swing.d6roll": chosenAttributeDie.roll,
                 "system.swing.attributeBonus": chosenAttributeDie.attribute.system.modifier,
                 "system.swing.value": chosenAttributeDie.roll + chosenAttributeDie.attribute.system.modifier
-            
             });
         }
         
@@ -473,6 +471,8 @@ export class Character extends Actor {
 
         this.update({
             "system.swing.attributeId": AttributeIdNoSwing,
+            "system.swing.d6roll": 0,
+            "system.swing.attributeBonus": 0,
             "system.swing.value": 0
         });
 

--- a/documents/character.mjs
+++ b/documents/character.mjs
@@ -137,8 +137,9 @@ export class Character extends Actor {
             templateValues.effect += attributeModifier;
         }
 
+        const actorRollData = this.getRollData()
         if (additionalDiceFormula?.toHit) {
-            const additionalRollToHit = await new Roll(additionalDiceFormula.toHit, this.system).evaluate();
+            const additionalRollToHit = await new Roll(additionalDiceFormula.toHit, actorRollData).evaluate();
             rolls.push(additionalRollToHit);
             templateValues.additionalDiceToHit = {
                 formula: additionalRollToHit.formula,
@@ -149,7 +150,7 @@ export class Character extends Actor {
         }
 
         if (additionalDiceFormula?.toEffect) {
-            const additionalRollToEffect = await new Roll(additionalDiceFormula.toEffect, this.system).evaluate();
+            const additionalRollToEffect = await new Roll(additionalDiceFormula.toEffect, actorRollData).evaluate();
             rolls.push(additionalRollToEffect);
             templateValues.additionalDiceToEffect = {
                 formula: additionalRollToEffect.formula,
@@ -302,8 +303,9 @@ export class Character extends Actor {
             existing: true
         } : null;
 
+        const actorRollData = this.getRollData()
         const attributeDice = await this.#rollAttributeDice(existingSwingAttributeDie);
-        const additionalDice = additionalDiceFormula?.toEffect ? await new Roll(additionalDiceFormula.toEffect, this.system).evaluate() : null;
+        const additionalDice = additionalDiceFormula?.toEffect ? await new Roll(additionalDiceFormula.toEffect, actorRollData).evaluate() : null;
         await this.#renderAttributeDice(options.rollTitle, attributeDice, additionalDice);
 
         const availableAttributeDice = attributeDice.filter((attributeDie) => attributeDie.attribute.system.status == AttributeStatus.Normal);


### PR DESCRIPTION
This pull request adds two things:
Firstly, I've added `actor.getRollData()` to the `Roll` instances in `additionalDiceFormula` so they can be accessed in the roll formulas.
This enables things like using `@swing.value` in the roll formulae (which also means you can do math with it!).

Secondly, I've added fields to `actor.system.swing` for the d6 roll and the attribute bonus of the swing individually, since I need those separately for one of the mechanics in my game. Completely fair if you want me to remove those.