### PR TITLE
Fix: The `init` hook was unnecessarily async

### DIFF
--- a/sentiment.mjs
+++ b/sentiment.mjs
@@ -26,7 +26,7 @@ import {
 import tryCreateCharacterMacro from "./macro.mjs"
 
 
-Hooks.once("init", async function () {
+Hooks.once("init", function () {
     console.log(`Initializing Sentiment System`); 
 
     CONFIG.Item.dataModels.attribute = AttributeData;
@@ -69,7 +69,7 @@ Hooks.once("init", async function () {
     Character.RegisterHandlebarsHelpers();
     CharacterSheet.RegisterHandlebarsHelpers();
 
-    await loadTemplates(["systems/sentiment/templates/partials/gift-list.html"]);
+    loadTemplates(["systems/sentiment/templates/partials/gift-list.html"]);
 });
 
 Hooks.on("hotbarDrop", (bar, data, slot) => tryCreateCharacterMacro(data, slot));


### PR DESCRIPTION
The `init` hook was async to `await loadTemplates()`. This isn't essential to `loadTemplates()`'s functionality in this case, and may prevent modules from accessing `CONFIG.Sentiment`.