### PR TITLE
Fix: Release all Attributes from lockout before Recovery Roll

### DIFF
--- a/documents/character.mjs
+++ b/documents/character.mjs
@@ -247,6 +247,8 @@ export class Character extends Actor {
             rollTitle: "Recovery Roll",
             totalStrategy: this.#totalAllAttributeRollsAndModifiers,
         }
+        
+        await this.#releaseAttributesFromLockout();
         const rollToDyeTotal = await this.#rollToDyeImpl(rollToDyeOptions, additionalDiceFormula);
         const newHealth = Math.min(this.system.health.value + rollToDyeTotal, this.system.health.max);
 
@@ -376,9 +378,14 @@ export class Character extends Actor {
     * Restore all locked-out attributes to normal status.
     * @private
     */
-    #releaseAttributesFromLockout() {
-        this.getAttributes().filter((attribute) => attribute.system.status === AttributeStatus.LockedOut).forEach((lockedOutAttribute) =>
-            lockedOutAttribute.update({ "system.status": AttributeStatus.Normal })
+    async #releaseAttributesFromLockout() {
+        const lockedOutAttributes = this.getAttributes()
+            .filter((attribute) => attribute.system.status === AttributeStatus.LockedOut);
+        if (lockedOutAttributes.length === 0) return;
+        await Promise.all(
+            lockedOutAttributes.map((lockedOutAttribute) =>
+                lockedOutAttribute.update({ "system.status": AttributeStatus.Normal })
+            )
         );
     }
 


### PR DESCRIPTION
According to the 0.9 ruledocs, locked out attributes are released before rolling to recover. 
> To Roll to Recover, Roll all of your Unwounded Attribute dice together. (Unlock any Locked dice for this Roll.)

This pull request implements this behavior.